### PR TITLE
g4: rild: re-doing the whole workaround (now wrild)

### DIFF
--- a/rootdir/bin/wrild.sh
+++ b/rootdir/bin/wrild.sh
@@ -1,0 +1,69 @@
+#!/system/bin/sh
+###################################################################################################
+#
+# workaround for randomly no SIM on boot (https://github.com/Suicide-Squirrel/issues_oreo/issues/6)
+#
+###################################################################################################
+x=1
+PRTRIGGER=0
+REQRESTART=99
+MAXRET=50
+
+F_RILCHK(){
+    CURSTATE=$(getprop gsm.sim.state)
+    CUROPER=$(getprop gsm.sim.operator.numeric)
+    echo "$0: gsm.sim.state >$CURSTATE<" >> /dev/kmsg
+    echo "$0: gsm.sim.operator.numeric >$CUROPER<" >> /dev/kmsg
+
+    if [ "$CURSTATE" == "READY" ]; then
+        echo 0
+    elif  [ "$CURSTATE" == "PIN_REQUIRED" ]; then
+        echo 9
+    elif [ "$CURSTATE" == "LOADED" ] && [ -z "$CUROPER" ];then
+        echo 1
+    elif [ "$CURSTATE" == "LOADED" ] && [ ! -z "$CUROPER" ];then
+        echo 0
+    else
+        echo 1
+    fi
+}
+
+while [ "$REQRESTART" -ne 0 ];do
+    REQRESTART=$(F_RILCHK)
+
+    # PIN_REQUIRED means usually the user get prompted - unfortunately 
+    # sometimes there is no prompt.
+    # this will restart RIL not on the first but every second run only (which should be safe) and
+    # let the user enough time to enter the PIN if the prompt appears
+    if [ "$REQRESTART" -eq 9 ]&&[ $PRTRIGGER -eq 0 ];then
+        echo "$0: PIN_REQUIRED detected. waiting 10s for user input.." >> /dev/kmsg && sleep 10
+        PRTRIGGER=1
+    elif [ "$REQRESTART" -eq 1 ];then
+        echo "$0: RIL restart - try $x of $MAXRET" >> /dev/kmsg
+        stop real-ril-daemon
+        sleep 1
+        start real-ril-daemon
+        echo "$0: restarted RIL daemon as REQRESTART was set to >$REQRESTART<" >> /dev/kmsg
+        sleep 20
+        PRTRIGGER=0
+    elif [ "$REQRESTART" -eq 9 ] ;then
+        echo "$0: PIN_REQUIRED detected. waiting another 20s for user input.." >> /dev/kmsg && sleep 20
+    elif [ "$REQRESTART" -eq 0 ] ;then
+        echo "$0: no restart required. RILD seems to work properly already." >> /dev/kmsg && break
+    else
+        echo "$0: unusual state detected . waiting 10s and will try again .." >> /dev/kmsg && sleep 20
+    fi
+    x=$((x + 1))
+    if [[ $x -eq $MAXRET ]];then
+        echo "$0: auto restart RIL daemon aborted.. too many tries!" >> /dev/kmsg
+        break
+    fi
+done
+
+MYPID=$(ps -opid,cmd|grep wrild.sh| egrep -o "[0-9]+")
+echo "$0: RIL should be fine now. Going to background with pid >$MYPID<" >> /dev/kmsg
+
+# run forever
+while true; do sleep 86400; done
+
+echo "$0: killed" >> /dev/kmsg

--- a/rootdir/etc/init.qcom.post_boot.sh
+++ b/rootdir/etc/init.qcom.post_boot.sh
@@ -202,35 +202,4 @@ if [ -c /dev/coresight-stm ]; then
     fi
 fi
 
-# workaround for randomly no SIM on boot (https://github.com/Suicide-Squirrel/issues_oreo/issues/6)
-x=1
-PRTRIGGER=0
-REQRESTART=$(getprop gsm.sim.state)
-while [ "$REQRESTART" != "READY" ];do
 
-    # PIN_REQUIRED means usually the user get prompted - unfortunately 
-    # sometimes there is no prompt.
-    # this will restart RIL not on the first but every second run only (which should be safe) and
-    # let the user enough time to enter the PIN if the prompt appears
-    if [ "$REQRESTART" == "PIN_REQUIRED" ]&&[ $PRTRIGGER -eq 0 ];then
-        echo "$0: PIN_REQUIRED detected. waiting 30s for user input.." >> /dev/kmsg && sleep 30
-        PRTRIGGER=1
-    else
-        echo "$0: RIL restart - try $x of 20" >> /dev/kmsg
-        stop ril-daemon
-        sleep 2
-        start ril-daemon
-        echo "$0: restarted RIL daemon as gsm.sim.state was >$REQRESTART<" >> /dev/kmsg
-        sleep 20
-        PRTRIGGER=0
-    fi
-    REQRESTART=$(getprop gsm.sim.state)
-    x=$((x + 1))
-    if [[ $x -eq 20 ]];then
-	echo "$0: auto restart RIL daemon aborted.. too many tries!" >> /dev/kmsg
-        break
-    fi
-done
-echo "$0: gsm.sim.state >$REQRESTART<" >> /dev/kmsg
-echo "$0: ended" >> /dev/kmsg
-# < END workaround

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -951,15 +951,19 @@ service qcom-post-boot /system/vendor/bin/init.qcom.post_boot.sh
     disabled
     oneshot
 
-#Group permissions for rild
-service ril-daemon /vendor/bin/hw/rild
-    class late_start
+# real rild started by wrild.sh
+service real-ril-daemon /vendor/bin/hw/rild
     socket qmux_radio/rild_oem0 stream 0777 radio system
     socket qmux_radio/qmux_client_socket stream 0777 radio system
     user root
     disabled
     group radio cache inet misc audio log readproc wakelock oem_2901 oem_2950 net_raw wifi diag
     capabilities BLOCK_SUSPEND NET_ADMIN NET_RAW
+
+# the rild wrapper which ensures proper rild handling
+service ril-daemon /system/bin/wrild.sh
+    user root
+    disabled
 
 on property:init.svc.ril-daemon=stopped
     start ril-daemon


### PR DESCRIPTION
1) the service ril-daemon has been renamed to real-ril-daemon
2) the service ril-daemon will start the (greatly enhanced) watchdog
     workaround for rild as a separated own binary (system/bin/wrild.sh)
3) wrild.sh will ensure that real-ril-daemon gets started and will
    watch MAXRET (def 50) times until rild comes up properly
4) instead of checking just the property of gsm.sim.state wrild will
     also check gsm.sim.operator.numeric in relation(!) to gsm.sim.state
     sometimes the gsm.sim.state is e.g. LOADED but rild is not working
     properly so gsm.sim.operator.numeric is checked as well which
     is only set when rild is fully working
     we cannot check simply for gsm.sim.operator.numeric though as e.g.
    there are states like PIN_REQUIRED
5) this implementation should fix several issues but mainly keeping stuck
     on boot and FC's for several stuff (system, cam etc) when using wrild in
     a previous version
6) wrild fixes several issues on the previous way in Oreo of checking and handling
     rild as well and should be applied to Oreo as well

A good way to test the above implementation:

adb logcat -b all |egrep "ril-dae|post_boot.sh|wrild"

Change-Id: If86453b7c191f3c4fb319d942a756fa4dd5dc231